### PR TITLE
PP-141: fix installation

### DIFF
--- a/sdk/zksync-crypto/build.sh
+++ b/sdk/zksync-crypto/build.sh
@@ -5,7 +5,7 @@ set -e
 BG_ASM=dist/zksync-crypto-bundler_bg_asm.js
 ASM=dist/zksync-crypto-bundler_asm.js
 
-which wasm-pack || cargo install --version 0.10.1 wasm-pack #version 0.10.2 leads to errors
+which wasm-pack || cargo install --version 0.10.1 wasm-pack #Dec 16th update to wasm-pack (v0.10.2) breaks zk init
 
 # pack for bundler (!note this verion is used in the pkg.browser field)
 wasm-pack build --release --target=bundler --out-name=zksync-crypto-bundler --out-dir=dist

--- a/sdk/zksync-crypto/build.sh
+++ b/sdk/zksync-crypto/build.sh
@@ -10,10 +10,14 @@ which wasm-pack || cargo install --version 0.10.1 wasm-pack #version 0.10.2 lead
 # pack for bundler (!note this verion is used in the pkg.browser field)
 wasm-pack build --release --target=bundler --out-name=zksync-crypto-bundler --out-dir=dist
 # pack for browser
-wasm-pack build --release --target=web --out-name=zksync-crypto-web --out-dir=dist
+wasm-pack build --release --target=web --out-name=zksync-crypto-web --out-dir=web-dist
 # pack for node.js
-wasm-pack build --release --target=nodejs --out-name=zksync-crypto-node --out-dir=dist
+wasm-pack build --release --target=nodejs --out-name=zksync-crypto-node --out-dir=node-dist
 
+# merge dist folders, wasm-pack delete out-dir folder before the new build
+mv web-dist/* dist/
+mv node-dist/* dist/
+rm -rf web-dist node-dist
 rm dist/package.json dist/.gitignore
 
 if [ "$CI" == "1" ]; then

--- a/sdk/zksync-crypto/build.sh
+++ b/sdk/zksync-crypto/build.sh
@@ -8,17 +8,13 @@ ASM=dist/zksync-crypto-bundler_asm.js
 which wasm-pack || cargo install --version 0.10.1 wasm-pack #version 0.10.2 leads to errors
 
 # pack for bundler (!note this verion is used in the pkg.browser field)
-wasm-pack build --release --target=bundler --out-name=zksync-crypto-bundler --out-dir=dist-bundler
+wasm-pack build --release --target=bundler --out-name=zksync-crypto-bundler --out-dir=dist
 # pack for browser
-wasm-pack build --release --target=web --out-name=zksync-crypto-web --out-dir=dist-web
+wasm-pack build --release --target=web --out-name=zksync-crypto-web --out-dir=dist
 # pack for node.js
-wasm-pack build --release --target=nodejs --out-name=zksync-crypto-node --out-dir=dist-nodejs
+wasm-pack build --release --target=nodejs --out-name=zksync-crypto-node --out-dir=dist
 
-mkdir -p dist
-cp -n dist-bundler/* dist-web/* dist-nodejs/* dist
-
-rm dist/package.json
-rm -r dist-bundler dist-web dist-nodejs
+rm dist/package.json dist/.gitignore
 
 if [ "$CI" == "1" ]; then
     exit 0


### PR DESCRIPTION
Executing `zk init` (after successfully running `zk`) on the `rsk_merge_master_Dec2021` branch throws the following error:

```bash
Failed opening './dist/zksync-crypto-bundler_bg.wasm'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
Command: /home/usr/.nvm/versions/node/v14.19.0/bin/node
Arguments: /usr/share/yarn/lib/cli.js build
Directory: /home/usr/github.com/rsksmart/aggregation/ri-aggregation/sdk/zksync-crypto
Output:

info Visit https://yarnpkg.com/en/docs/cli/workspace for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Child process exited with code 1
```

This happens because some of the build commands target the same folder (`dist`). This has been confirmed to occur in both linux and mac.

This PR cherry-picks commits present on `matter-labs/zksync:master` to fix this problem.