### PR TITLE
ROLLUP-31: Add support for RDOC

### DIFF
--- a/core/bin/zksync_api/src/fee_ticker/ticker_api/mod.rs
+++ b/core/bin/zksync_api/src/fee_ticker/ticker_api/mod.rs
@@ -227,7 +227,7 @@ impl<T: TokenPriceAPI + Send + Sync> FeeTickerAPI for TickerApi<T> {
             .ok_or_else(|| PriceError::token_not_found(format!("Token not found: {:?}", token)))?;
 
         // TODO: remove hardcode for Matter Labs Trial Token (ZKS-63).
-        if token.symbol == "MLTT" {
+        if token.symbol == "RDOC" {
             metrics::histogram!("ticker.get_last_quote", start.elapsed());
             return Ok(TokenPrice {
                 usd_price: Ratio::from_integer(1u32.into()),
@@ -316,3 +316,16 @@ impl<T: TokenPriceAPI + Send + Sync> FeeTickerAPI for TickerApi<T> {
         }
     }
 }
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     #[test]
+//     #[should_panic]
+//     fn should_return_one_for_rdoc() {
+//         tickerApi::TickerApi
+//     }
+
+//     fn should_return
+// }

--- a/infrastructure/zk/src/run/run.ts
+++ b/infrastructure/zk/src/run/run.ts
@@ -14,6 +14,7 @@ export async function deployERC20(command: 'dev' | 'new', name?: string, symbol?
     if (command == 'dev') {
         await utils.spawn(`yarn --silent --cwd contracts deploy-erc20 add-multi '
             [
+                { "name": "RDOC",  "symbol": "RDOC",  "decimals": 18 }
             ]' > ./etc/tokens/localhost.json`);
         if (!process.env.CI) {
             await docker.restart('dev-liquidity-token-watcher');


### PR DESCRIPTION
## What

-   Hardcode the value of RDOC in the price feeder to always return 1.

## Why

-  Add support for RDOC as token.

## Refs

-   [ROLLUP-158](https://rsklabs.atlassian.net/browse/ROLLUP-158)