### PR TITLE
ROLLUP-158: Add support for RDOC 

### DIFF
--- a/core/bin/zksync_api/src/fee_ticker/tests.rs
+++ b/core/bin/zksync_api/src/fee_ticker/tests.rs
@@ -682,17 +682,20 @@ async fn test_error_api() {
 #[tokio::test]
 #[ignore]
 async fn test_rdoc_price() {
+    const DATABASE_URL: &str = "postgres://postgres@localhost/plasma";
+    const BASE_URL: &str = "http://127.0.0.1:9876";
+    const RDOC_SYMBOL: &str = "RDOC";
+
     let client = reqwest::ClientBuilder::new()
         .timeout(CONNECTION_TIMEOUT)
         .connect_timeout(CONNECTION_TIMEOUT)
         .build()
         .expect("Failed to build reqwest::Client");
 
-    env::set_var("DATABASE_URL", "postgres://postgres@localhost/plasma");
+    env::set_var("DATABASE_URL", DATABASE_URL);
 
-    let base_url = "http://127.0.0.1:9876";
     let token_price_api =
-        CoinMarketCapAPI::new(client, base_url.parse().expect("Correct CoinMarketCap url"));
+        CoinMarketCapAPI::new(client, BASE_URL.parse().expect("Correct CoinMarketCap url"));
     let connection_pool = ConnectionPool::new(Some(1));
     let ticker_api = TickerApi::new(connection_pool.clone(), token_price_api);
 
@@ -713,7 +716,7 @@ async fn test_rdoc_price() {
         validator,
     );
 
-    let token = TokenLike::Symbol(format!("RDOC"));
+    let token = TokenLike::Symbol(String::from(RDOC_SYMBOL));
     let token_price = fee_ticker
         .get_token_price(token, TokenPriceRequestType::USDForOneToken)
         .await

--- a/core/bin/zksync_api/src/fee_ticker/ticker_api/mod.rs
+++ b/core/bin/zksync_api/src/fee_ticker/ticker_api/mod.rs
@@ -227,7 +227,7 @@ impl<T: TokenPriceAPI + Send + Sync> FeeTickerAPI for TickerApi<T> {
             .ok_or_else(|| PriceError::token_not_found(format!("Token not found: {:?}", token)))?;
 
         // TODO: remove hardcode for Matter Labs Trial Token (ZKS-63).
-        if token.symbol == "MLTT" {
+        if token.symbol == "RDOC" {
             metrics::histogram!("ticker.get_last_quote", start.elapsed());
             return Ok(TokenPrice {
                 usd_price: Ratio::from_integer(1u32.into()),
@@ -316,3 +316,16 @@ impl<T: TokenPriceAPI + Send + Sync> FeeTickerAPI for TickerApi<T> {
         }
     }
 }
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     #[test]
+//     #[should_panic]
+//     fn should_return_one_for_rdoc() {
+//         tickerApi::TickerApi
+//     }
+
+//     fn should_return
+// }

--- a/infrastructure/zk/src/run/run.ts
+++ b/infrastructure/zk/src/run/run.ts
@@ -14,6 +14,7 @@ export async function deployERC20(command: 'dev' | 'new', name?: string, symbol?
     if (command == 'dev') {
         await utils.spawn(`yarn --silent --cwd contracts deploy-erc20 add-multi '
             [
+                { "name": "RDOC",  "symbol": "RDOC",  "decimals": 18 }
             ]' > ./etc/tokens/localhost.json`);
         if (!process.env.CI) {
             await docker.restart('dev-liquidity-token-watcher');


### PR DESCRIPTION
## What

-   Hardcode the value of RDOC in the price feeder to always return 1.

## Why

-  Add support for RDOC as token.

## Refs

-   [ROLLUP-158](https://rsklabs.atlassian.net/browse/ROLLUP-158)